### PR TITLE
Implemented Profile - 1080p x265 HDR

### DIFF
--- a/imports/custom_formats/radarr/custom formats (radarr - master).json
+++ b/imports/custom_formats/radarr/custom formats (radarr - master).json
@@ -50,6 +50,88 @@
                         "isFloat": false
                     }
                 ]
+            },
+            {
+                "name": "WEB",
+                "implementation": "SourceSpecification",
+                "implementationName": "Source",
+                "infoLink": "https://wiki.servarr.com/radarr/settings#custom-formats-2",
+                "negate": true,
+                "required": true,
+                "fields": [
+                    {
+                        "order": 0,
+                        "name": "value",
+                        "label": "Source",
+                        "value": 7,
+                        "type": "select",
+                        "advanced": false,
+                        "selectOptions": [
+                            {
+                                "value": 0,
+                                "name": "UNKNOWN",
+                                "order": 0,
+                                "dividerAfter": false
+                            },
+                            {
+                                "value": 1,
+                                "name": "CAM",
+                                "order": 1,
+                                "dividerAfter": false
+                            },
+                            {
+                                "value": 2,
+                                "name": "TELESYNC",
+                                "order": 2,
+                                "dividerAfter": false
+                            },
+                            {
+                                "value": 3,
+                                "name": "TELECINE",
+                                "order": 3,
+                                "dividerAfter": false
+                            },
+                            {
+                                "value": 4,
+                                "name": "WORKPRINT",
+                                "order": 4,
+                                "dividerAfter": false
+                            },
+                            {
+                                "value": 5,
+                                "name": "DVD",
+                                "order": 5,
+                                "dividerAfter": false
+                            },
+                            {
+                                "value": 6,
+                                "name": "TV",
+                                "order": 6,
+                                "dividerAfter": false
+                            },
+                            {
+                                "value": 7,
+                                "name": "WEBDL",
+                                "order": 7,
+                                "dividerAfter": false
+                            },
+                            {
+                                "value": 8,
+                                "name": "WEBRIP",
+                                "order": 8,
+                                "dividerAfter": false
+                            },
+                            {
+                                "value": 9,
+                                "name": "BLURAY",
+                                "order": 9,
+                                "dividerAfter": false
+                            }
+                        ],
+                        "privacy": "normal",
+                        "isFloat": false
+                    }
+                ]
             }
         ]
     },
@@ -6948,6 +7030,279 @@
                         "isFloat": false
                     }
                 ]
+            },
+            {
+                "name": "CRX",
+                "implementation": "ReleaseGroupSpecification",
+                "implementationName": "Release Group",
+                "infoLink": "https://wiki.servarr.com/radarr/settings#custom-formats-2",
+                "negate": true,
+                "required": true,
+                "fields": [
+                    {
+                        "order": 0,
+                        "name": "value",
+                        "label": "Regular Expression",
+                        "helpText": "Custom Format RegEx is Case Insensitive",
+                        "value": "(?<=^|[\\s.-])CRX\\b",
+                        "type": "textbox",
+                        "advanced": false,
+                        "privacy": "normal",
+                        "isFloat": false
+                    }
+                ]
+            },
+            {
+                "name": "playWEB",
+                "implementation": "ReleaseGroupSpecification",
+                "implementationName": "Release Group",
+                "infoLink": "https://wiki.servarr.com/radarr/settings#custom-formats-2",
+                "negate": true,
+                "required": true,
+                "fields": [
+                    {
+                        "order": 0,
+                        "name": "value",
+                        "label": "Regular Expression",
+                        "helpText": "Custom Format RegEx is Case Insensitive",
+                        "value": "(?<=^|[\\s.-])playWEB\\b",
+                        "type": "textbox",
+                        "advanced": false,
+                        "privacy": "normal",
+                        "isFloat": false
+                    }
+                ]
+            },
+            {
+                "name": "playSD",
+                "implementation": "ReleaseGroupSpecification",
+                "implementationName": "Release Group",
+                "infoLink": "https://wiki.servarr.com/radarr/settings#custom-formats-2",
+                "negate": true,
+                "required": true,
+                "fields": [
+                    {
+                        "order": 0,
+                        "name": "value",
+                        "label": "Regular Expression",
+                        "helpText": "Custom Format RegEx is Case Insensitive",
+                        "value": "(?<=^|[\\s.-])playSD\\b",
+                        "type": "textbox",
+                        "advanced": false,
+                        "privacy": "normal",
+                        "isFloat": false
+                    }
+                ]
+            },
+            {
+                "name": "playBD",
+                "implementation": "ReleaseGroupSpecification",
+                "implementationName": "Release Group",
+                "infoLink": "https://wiki.servarr.com/radarr/settings#custom-formats-2",
+                "negate": true,
+                "required": true,
+                "fields": [
+                    {
+                        "order": 0,
+                        "name": "value",
+                        "label": "Regular Expression",
+                        "helpText": "Custom Format RegEx is Case Insensitive",
+                        "value": "(?<=^|[\\s.-])playBD\\b",
+                        "type": "textbox",
+                        "advanced": false,
+                        "privacy": "normal",
+                        "isFloat": false
+                    }
+                ]
+            },
+            {
+                "name": "iROBOT",
+                "implementation": "ReleaseGroupSpecification",
+                "implementationName": "Release Group",
+                "infoLink": "https://wiki.servarr.com/radarr/settings#custom-formats-2",
+                "negate": true,
+                "required": true,
+                "fields": [
+                    {
+                        "order": 0,
+                        "name": "value",
+                        "label": "Regular Expression",
+                        "helpText": "Custom Format RegEx is Case Insensitive",
+                        "value": "(?<=^|[\\s.-])iROBOT\\b",
+                        "type": "textbox",
+                        "advanced": false,
+                        "privacy": "normal",
+                        "isFloat": false
+                    }
+                ]
+            },
+            {
+                "name": "RPG",
+                "implementation": "ReleaseGroupSpecification",
+                "implementationName": "Release Group",
+                "infoLink": "https://wiki.servarr.com/radarr/settings#custom-formats-2",
+                "negate": true,
+                "required": true,
+                "fields": [
+                    {
+                        "order": 0,
+                        "name": "value",
+                        "label": "Regular Expression",
+                        "helpText": "Custom Format RegEx is Case Insensitive",
+                        "value": "(?<=^|[\\s.-])RPG\\b",
+                        "type": "textbox",
+                        "advanced": false,
+                        "privacy": "normal",
+                        "isFloat": false
+                    }
+                ]
+            },
+            {
+                "name": "MKVULTRA",
+                "implementation": "ReleaseGroupSpecification",
+                "implementationName": "Release Group",
+                "infoLink": "https://wiki.servarr.com/radarr/settings#custom-formats-2",
+                "negate": true,
+                "required": true,
+                "fields": [
+                    {
+                        "order": 0,
+                        "name": "value",
+                        "label": "Regular Expression",
+                        "helpText": "Custom Format RegEx is Case Insensitive",
+                        "value": "(?<=^|[\\s.-])MKVULTRA\\b",
+                        "type": "textbox",
+                        "advanced": false,
+                        "privacy": "normal",
+                        "isFloat": false
+                    }
+                ]
+            },
+            {
+                "name": "-ZR-",
+                "implementation": "ReleaseGroupSpecification",
+                "implementationName": "Release Group",
+                "infoLink": "https://wiki.servarr.com/radarr/settings#custom-formats-2",
+                "negate": true,
+                "required": true,
+                "fields": [
+                    {
+                        "order": 0,
+                        "name": "value",
+                        "label": "Regular Expression",
+                        "helpText": "Custom Format RegEx is Case Insensitive",
+                        "value": "(?<=^|[\\s.-])\\-ZR\\-\\b",
+                        "type": "textbox",
+                        "advanced": false,
+                        "privacy": "normal",
+                        "isFloat": false
+                    }
+                ]
+            },
+            {
+                "name": "S0NNY",
+                "implementation": "ReleaseGroupSpecification",
+                "implementationName": "Release Group",
+                "infoLink": "https://wiki.servarr.com/radarr/settings#custom-formats-2",
+                "negate": true,
+                "required": true,
+                "fields": [
+                    {
+                        "order": 0,
+                        "name": "value",
+                        "label": "Regular Expression",
+                        "helpText": "Custom Format RegEx is Case Insensitive",
+                        "value": "(?<=^|[\\s.-])S0NNY\\b",
+                        "type": "textbox",
+                        "advanced": false,
+                        "privacy": "normal",
+                        "isFloat": false
+                    }
+                ]
+            },
+            {
+                "name": "CRFW",
+                "implementation": "ReleaseGroupSpecification",
+                "implementationName": "Release Group",
+                "infoLink": "https://wiki.servarr.com/radarr/settings#custom-formats-2",
+                "negate": true,
+                "required": true,
+                "fields": [
+                    {
+                        "order": 0,
+                        "name": "value",
+                        "label": "Regular Expression",
+                        "helpText": "Custom Format RegEx is Case Insensitive",
+                        "value": "(?<=^|[\\s.-])CRFW\\b",
+                        "type": "textbox",
+                        "advanced": false,
+                        "privacy": "normal",
+                        "isFloat": false
+                    }
+                ]
+            },
+            {
+                "name": "CRX: CRX",
+                "implementation": "ReleaseGroupSpecification",
+                "implementationName": "Release Group",
+                "infoLink": "https://wiki.servarr.com/radarr/settings#custom-formats-2",
+                "negate": true,
+                "required": true,
+                "fields": [
+                    {
+                        "order": 0,
+                        "name": "value",
+                        "label": "Regular Expression",
+                        "helpText": "Custom Format RegEx is Case Insensitive",
+                        "value": "(?<=^|[\\s.-])CRX\\b",
+                        "type": "textbox",
+                        "advanced": false,
+                        "privacy": "normal",
+                        "isFloat": false
+                    }
+                ]
+            },
+            {
+                "name": "EXCiSiON: EXCiSiON",
+                "implementation": "ReleaseGroupSpecification",
+                "implementationName": "Release Group",
+                "infoLink": "https://wiki.servarr.com/radarr/settings#custom-formats-2",
+                "negate": true,
+                "required": true,
+                "fields": [
+                    {
+                        "order": 0,
+                        "name": "value",
+                        "label": "Regular Expression",
+                        "helpText": "Custom Format RegEx is Case Insensitive",
+                        "value": "(?<=^|[\\s.-])EXCiSiON\\b",
+                        "type": "textbox",
+                        "advanced": false,
+                        "privacy": "normal",
+                        "isFloat": false
+                    }
+                ]
+            },
+            {
+                "name": "E1",
+                "implementation": "ReleaseTitleSpecification",
+                "implementationName": "Release Title",
+                "infoLink": "https://wiki.servarr.com/radarr/settings#custom-formats-2",
+                "negate": true,
+                "required": true,
+                "fields": [
+                    {
+                        "order": 0,
+                        "name": "value",
+                        "label": "Regular Expression",
+                        "helpText": "Custom Format RegEx is Case Insensitive",
+                        "value": "(?<=^|[\\s.-])E1\\b",
+                        "type": "textbox",
+                        "advanced": false,
+                        "privacy": "normal",
+                        "isFloat": false
+                    }
+                ]
             }
         ]
     },
@@ -9851,76 +10206,6 @@
                         "value": "\\[\\d{4}\\]",
                         "type": "textbox",
                         "advanced": false,
-                        "privacy": "normal",
-                        "isFloat": false
-                    }
-                ]
-            },
-            {
-                "name": "2160p",
-                "implementation": "ResolutionSpecification",
-                "implementationName": "Resolution",
-                "infoLink": "https://wiki.servarr.com/radarr/settings#custom-formats-2",
-                "negate": false,
-                "required": true,
-                "fields": [
-                    {
-                        "order": 0,
-                        "name": "value",
-                        "label": "Resolution",
-                        "value": 2160,
-                        "type": "select",
-                        "advanced": false,
-                        "selectOptions": [
-                            {
-                                "value": 0,
-                                "name": "Unknown",
-                                "order": 0,
-                                "dividerAfter": false
-                            },
-                            {
-                                "value": 360,
-                                "name": "R360p",
-                                "order": 360,
-                                "dividerAfter": false
-                            },
-                            {
-                                "value": 480,
-                                "name": "R480p",
-                                "order": 480,
-                                "dividerAfter": false
-                            },
-                            {
-                                "value": 540,
-                                "name": "R540p",
-                                "order": 540,
-                                "dividerAfter": false
-                            },
-                            {
-                                "value": 576,
-                                "name": "R576p",
-                                "order": 576,
-                                "dividerAfter": false
-                            },
-                            {
-                                "value": 720,
-                                "name": "R720p",
-                                "order": 720,
-                                "dividerAfter": false
-                            },
-                            {
-                                "value": 1080,
-                                "name": "R1080p",
-                                "order": 1080,
-                                "dividerAfter": false
-                            },
-                            {
-                                "value": 2160,
-                                "name": "R2160p",
-                                "order": 2160,
-                                "dividerAfter": false
-                            }
-                        ],
                         "privacy": "normal",
                         "isFloat": false
                     }
@@ -13292,6 +13577,405 @@
                         "label": "Regular Expression",
                         "helpText": "Custom Format RegEx is Case Insensitive",
                         "value": "(?<=^|[\\s.-])jennaortegaUHD\\b",
+                        "type": "textbox",
+                        "advanced": false,
+                        "privacy": "normal",
+                        "isFloat": false
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "name": "UHD Bluray",
+        "includeCustomFormatWhenRenaming": false,
+        "specifications": [
+            {
+                "name": "UHD Bluray",
+                "implementation": "ReleaseTitleSpecification",
+                "implementationName": "Release Title",
+                "infoLink": "https://wiki.servarr.com/radarr/settings#custom-formats-2",
+                "negate": false,
+                "required": true,
+                "fields": [
+                    {
+                        "order": 0,
+                        "name": "value",
+                        "label": "Regular Expression",
+                        "helpText": "Custom Format RegEx is Case Insensitive",
+                        "value": "\\buhd[- ._]bluray\\b",
+                        "type": "textbox",
+                        "advanced": false,
+                        "privacy": "normal",
+                        "isFloat": false
+                    }
+                ]
+            },
+            {
+                "name": "HDR",
+                "implementation": "ReleaseTitleSpecification",
+                "implementationName": "Release Title",
+                "infoLink": "https://wiki.servarr.com/radarr/settings#custom-formats-2",
+                "negate": false,
+                "required": true,
+                "fields": [
+                    {
+                        "order": 0,
+                        "name": "value",
+                        "label": "Regular Expression",
+                        "helpText": "Custom Format RegEx is Case Insensitive",
+                        "value": "\\b(dv|dovi|dolby[ .]?vision)\\b|HDR",
+                        "type": "textbox",
+                        "advanced": false,
+                        "privacy": "normal",
+                        "isFloat": false
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "name": "HDR10 (Missing) (x265 HDR only)",
+        "includeCustomFormatWhenRenaming": false,
+        "specifications": [
+            {
+                "name": "Not SDR",
+                "implementation": "ReleaseTitleSpecification",
+                "implementationName": "Release Title",
+                "infoLink": "https://wiki.servarr.com/radarr/settings#custom-formats-2",
+                "negate": true,
+                "required": true,
+                "fields": [
+                    {
+                        "order": 0,
+                        "name": "value",
+                        "label": "Regular Expression",
+                        "helpText": "Custom Format RegEx is Case Insensitive",
+                        "value": "\\bSDR(\\b|\\d)",
+                        "type": "textbox",
+                        "advanced": false,
+                        "privacy": "normal",
+                        "isFloat": false
+                    }
+                ]
+            },
+            {
+                "name": "Not HDR10+",
+                "implementation": "ReleaseTitleSpecification",
+                "implementationName": "Release Title",
+                "infoLink": "https://wiki.servarr.com/radarr/settings#custom-formats-2",
+                "negate": true,
+                "required": true,
+                "fields": [
+                    {
+                        "order": 0,
+                        "name": "value",
+                        "label": "Regular Expression",
+                        "helpText": "Custom Format RegEx is Case Insensitive",
+                        "value": "\\bHDR10(\\+|P(lus)?\\b)",
+                        "type": "textbox",
+                        "advanced": false,
+                        "privacy": "normal",
+                        "isFloat": false
+                    }
+                ]
+            },
+            {
+                "name": "HDR",
+                "implementation": "ReleaseTitleSpecification",
+                "implementationName": "Release Title",
+                "infoLink": "https://wiki.servarr.com/radarr/settings#custom-formats-2",
+                "negate": true,
+                "required": true,
+                "fields": [
+                    {
+                        "order": 0,
+                        "name": "value",
+                        "label": "Regular Expression",
+                        "helpText": "Custom Format RegEx is Case Insensitive",
+                        "value": "HDR",
+                        "type": "textbox",
+                        "advanced": false,
+                        "privacy": "normal",
+                        "isFloat": false
+                    }
+                ]
+            },
+            {
+                "name": "DV",
+                "implementation": "ReleaseTitleSpecification",
+                "implementationName": "Release Title",
+                "infoLink": "https://wiki.servarr.com/radarr/settings#custom-formats-2",
+                "negate": false,
+                "required": true,
+                "fields": [
+                    {
+                        "order": 0,
+                        "name": "value",
+                        "label": "Regular Expression",
+                        "helpText": "Custom Format RegEx is Case Insensitive",
+                        "value": "\\b(dv|dovi|dolby[ .]?vision)\\b",
+                        "type": "textbox",
+                        "advanced": false,
+                        "privacy": "normal",
+                        "isFloat": false
+                    }
+                ]
+            },
+            {
+                "name": "1080p",
+                "implementation": "ReleaseTitleSpecification",
+                "implementationName": "Release Title",
+                "infoLink": "https://wiki.servarr.com/radarr/settings#custom-formats-2",
+                "negate": false,
+                "required": true,
+                "fields": [
+                    {
+                        "order": 0,
+                        "name": "value",
+                        "label": "Regular Expression",
+                        "helpText": "Custom Format RegEx is Case Insensitive",
+                        "value": "[.\\- (\\[]?1080p",
+                        "type": "textbox",
+                        "advanced": false,
+                        "privacy": "normal",
+                        "isFloat": false
+                    }
+                ]
+            },
+            {
+                "name": "x265",
+                "implementation": "ReleaseTitleSpecification",
+                "implementationName": "Release Title",
+                "infoLink": "https://wiki.servarr.com/radarr/settings#custom-formats-2",
+                "negate": false,
+                "required": true,
+                "fields": [
+                    {
+                        "order": 0,
+                        "name": "value",
+                        "label": "Regular Expression",
+                        "helpText": "Custom Format RegEx is Case Insensitive",
+                        "value": "^(?!.*(?i:remux)).*([x]\\s?(\\.?265))",
+                        "type": "textbox",
+                        "advanced": false,
+                        "privacy": "normal",
+                        "isFloat": false
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "name": "CRX",
+        "includeCustomFormatWhenRenaming": true,
+        "specifications": [
+            {
+                "name": "CRX",
+                "implementation": "ReleaseGroupSpecification",
+                "implementationName": "Release Group",
+                "infoLink": "https://wiki.servarr.com/radarr/settings#custom-formats-2",
+                "negate": false,
+                "required": true,
+                "fields": [
+                    {
+                        "order": 0,
+                        "name": "value",
+                        "label": "Regular Expression",
+                        "helpText": "Custom Format RegEx is Case Insensitive",
+                        "value": "(?<=^|[\\s.-])CRX\\b",
+                        "type": "textbox",
+                        "advanced": false,
+                        "privacy": "normal",
+                        "isFloat": false
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Unwanted x265 Groups",
+        "includeCustomFormatWhenRenaming": false,
+        "specifications": [
+            {
+                "name": "SM737",
+                "implementation": "ReleaseGroupSpecification",
+                "implementationName": "Release Group",
+                "infoLink": "https://wiki.servarr.com/radarr/settings#custom-formats-2",
+                "negate": false,
+                "required": false,
+                "fields": [
+                    {
+                        "order": 0,
+                        "name": "value",
+                        "label": "Regular Expression",
+                        "helpText": "Custom Format RegEx is Case Insensitive",
+                        "value": "(?<=^|[\\s.-])SM737\\b",
+                        "type": "textbox",
+                        "advanced": false,
+                        "privacy": "normal",
+                        "isFloat": false
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "name": "EXCiSiON",
+        "includeCustomFormatWhenRenaming": false,
+        "specifications": [
+            {
+                "name": "EXCiSiON",
+                "implementation": "ReleaseGroupSpecification",
+                "implementationName": "Release Group",
+                "infoLink": "https://wiki.servarr.com/radarr/settings#custom-formats-2",
+                "negate": false,
+                "required": true,
+                "fields": [
+                    {
+                        "order": 0,
+                        "name": "value",
+                        "label": "Regular Expression",
+                        "helpText": "Custom Format RegEx is Case Insensitive",
+                        "value": "(?<=^|[\\s.-])EXCiSiON\\b",
+                        "type": "textbox",
+                        "advanced": false,
+                        "privacy": "normal",
+                        "isFloat": false
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "name": "2160p x265",
+        "includeCustomFormatWhenRenaming": false,
+        "specifications": [
+            {
+                "name": "x265",
+                "implementation": "ReleaseTitleSpecification",
+                "implementationName": "Release Title",
+                "infoLink": "https://wiki.servarr.com/radarr/settings#custom-formats-2",
+                "negate": false,
+                "required": true,
+                "fields": [
+                    {
+                        "order": 0,
+                        "name": "value",
+                        "label": "Regular Expression",
+                        "helpText": "Custom Format RegEx is Case Insensitive",
+                        "value": "^(?!.*(?i:remux)).*([x]\\s?(\\.?265))",
+                        "type": "textbox",
+                        "advanced": false,
+                        "privacy": "normal",
+                        "isFloat": false
+                    }
+                ]
+            },
+            {
+                "name": "Disc",
+                "implementation": "ReleaseTitleSpecification",
+                "implementationName": "Release Title",
+                "infoLink": "https://wiki.servarr.com/radarr/settings#custom-formats-2",
+                "negate": true,
+                "required": true,
+                "fields": [
+                    {
+                        "order": 0,
+                        "name": "value",
+                        "label": "Regular Expression",
+                        "helpText": "Custom Format RegEx is Case Insensitive",
+                        "value": "^(?!.*\\b((?<!HD[._ -]|HD)DVD|BDRip|MKV|XviD|WMV|d3g|BDREMUX|REMUX|^(?=.*1080p)(?=.*HEVC)|[xh][-_. ]?26[45]|German.*DL|((?<=\\d{4}).*German.*(DL)?)(?=.*\\b(AVC|HEVC|VC[-_. ]?1|MVC|MPEG[-_. ]?2)\\b))\\b)(((?=.*\\b(Blu[-_. ]?ray|BD|HD[-_. ]?DVD)\\b)(?=.*\\b(AVC|HEVC|VC[-_. ]?1|MVC|MPEG[-_. ]?2|BDMV|ISO)\\b))|^((?=.*\\b(^((?=.*\\b((.*_)?COMPLETE.*|Dis[ck])\\b)(?=.*(Blu[-_. ]?ray|HD[-_. ]?DVD)))|3D[-_. ]?BD|BR[-_. ]?DISK|Full[-_. ]?Blu[-_. ]?ray|^((?=.*((BD|UHD)[-_. ]?(25|50|66|100|ISO)))))))).*|(?i)(DVD9|DVD5|NTSC|PAL|VOB IFO|VC-1|AVC|MPEG-2|\\bCOMPLETE[-.\\s]?(?:UHD[-.\\s])?BLU[-.\\s]?RAY\\b|\\bCOMPLETE BLURAY\\b|\\bBR-Disk\\b)",
+                        "type": "textbox",
+                        "advanced": false,
+                        "privacy": "normal",
+                        "isFloat": false
+                    }
+                ]
+            },
+            {
+                "name": "Remux",
+                "implementation": "ReleaseTitleSpecification",
+                "implementationName": "Release Title",
+                "infoLink": "https://wiki.servarr.com/radarr/settings#custom-formats-2",
+                "negate": true,
+                "required": true,
+                "fields": [
+                    {
+                        "order": 0,
+                        "name": "value",
+                        "label": "Regular Expression",
+                        "helpText": "Custom Format RegEx is Case Insensitive",
+                        "value": "(?i)(REMUX|DVDRip)",
+                        "type": "textbox",
+                        "advanced": false,
+                        "privacy": "normal",
+                        "isFloat": false
+                    }
+                ]
+            },
+            {
+                "name": "2160p",
+                "implementation": "ReleaseTitleSpecification",
+                "implementationName": "Release Title",
+                "infoLink": "https://wiki.servarr.com/radarr/settings#custom-formats-2",
+                "negate": false,
+                "required": true,
+                "fields": [
+                    {
+                        "order": 0,
+                        "name": "value",
+                        "label": "Regular Expression",
+                        "helpText": "Custom Format RegEx is Case Insensitive",
+                        "value": "(?<=^|[\\s.\\-(])(2160p|UHD)\\b",
+                        "type": "textbox",
+                        "advanced": false,
+                        "privacy": "normal",
+                        "isFloat": false
+                    }
+                ]
+            },
+            {
+                "name": "1080p",
+                "implementation": "ReleaseTitleSpecification",
+                "implementationName": "Release Title",
+                "infoLink": "https://wiki.servarr.com/radarr/settings#custom-formats-2",
+                "negate": true,
+                "required": true,
+                "fields": [
+                    {
+                        "order": 0,
+                        "name": "value",
+                        "label": "Regular Expression",
+                        "helpText": "Custom Format RegEx is Case Insensitive",
+                        "value": "[.\\- (\\[]?1080p",
+                        "type": "textbox",
+                        "advanced": false,
+                        "privacy": "normal",
+                        "isFloat": false
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "name": "E1",
+        "includeCustomFormatWhenRenaming": true,
+        "specifications": [
+            {
+                "name": "E1",
+                "implementation": "ReleaseTitleSpecification",
+                "implementationName": "Release Title",
+                "infoLink": "https://wiki.servarr.com/radarr/settings#custom-formats-2",
+                "negate": false,
+                "required": true,
+                "fields": [
+                    {
+                        "order": 0,
+                        "name": "value",
+                        "label": "Regular Expression",
+                        "helpText": "Custom Format RegEx is Case Insensitive",
+                        "value": "(?<=^|[\\s.-])E1\\b",
                         "type": "textbox",
                         "advanced": false,
                         "privacy": "normal",

--- a/imports/custom_formats/radarr/custom formats (radarr - master).json
+++ b/imports/custom_formats/radarr/custom formats (radarr - master).json
@@ -12988,27 +12988,6 @@
         "includeCustomFormatWhenRenaming": false,
         "specifications": [
             {
-                "name": "h265",
-                "implementation": "ReleaseTitleSpecification",
-                "implementationName": "Release Title",
-                "infoLink": "https://wiki.servarr.com/radarr/settings#custom-formats-2",
-                "negate": false,
-                "required": true,
-                "fields": [
-                    {
-                        "order": 0,
-                        "name": "value",
-                        "label": "Regular Expression",
-                        "helpText": "Custom Format RegEx is Case Insensitive",
-                        "value": "(?i)h\\s*\\.?\\s*265",
-                        "type": "textbox",
-                        "advanced": false,
-                        "privacy": "normal",
-                        "isFloat": false
-                    }
-                ]
-            },
-            {
                 "name": "Disc",
                 "implementation": "ReleaseTitleSpecification",
                 "implementationName": "Release Title",
@@ -13976,6 +13955,54 @@
                         "label": "Regular Expression",
                         "helpText": "Custom Format RegEx is Case Insensitive",
                         "value": "(?<=^|[\\s.-])E1\\b",
+                        "type": "textbox",
+                        "advanced": false,
+                        "privacy": "normal",
+                        "isFloat": false
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "name": "BHDStudio (1080p x265)",
+        "includeCustomFormatWhenRenaming": false,
+        "specifications": [
+            {
+                "name": "BHDStudio",
+                "implementation": "ReleaseTitleSpecification",
+                "implementationName": "Release Title",
+                "infoLink": "https://wiki.servarr.com/radarr/settings#custom-formats-2",
+                "negate": false,
+                "required": true,
+                "fields": [
+                    {
+                        "order": 0,
+                        "name": "value",
+                        "label": "Regular Expression",
+                        "helpText": "Custom Format RegEx is Case Insensitive",
+                        "value": "(?<=^|[\\s.-])BHDStudio\\b",
+                        "type": "textbox",
+                        "advanced": false,
+                        "privacy": "normal",
+                        "isFloat": false
+                    }
+                ]
+            },
+            {
+                "name": "x265",
+                "implementation": "ReleaseTitleSpecification",
+                "implementationName": "Release Title",
+                "infoLink": "https://wiki.servarr.com/radarr/settings#custom-formats-2",
+                "negate": false,
+                "required": true,
+                "fields": [
+                    {
+                        "order": 0,
+                        "name": "value",
+                        "label": "Regular Expression",
+                        "helpText": "Custom Format RegEx is Case Insensitive",
+                        "value": "^(?!.*(?i:remux)).*([x]\\s?(\\.?265))",
                         "type": "textbox",
                         "advanced": false,
                         "privacy": "normal",

--- a/imports/quality_profiles/radarr/1080p Balanced (Single Grab) (radarr - master).json
+++ b/imports/quality_profiles/radarr/1080p Balanced (Single Grab) (radarr - master).json
@@ -367,6 +367,46 @@
         "cutoffFormatScore": 0,
         "formatItems": [
             {
+                "format": 353,
+                "name": "BHDStudio (1080p x265)",
+                "score": 0
+            },
+            {
+                "format": 352,
+                "name": "E1",
+                "score": 0
+            },
+            {
+                "format": 351,
+                "name": "2160p x265",
+                "score": 0
+            },
+            {
+                "format": 349,
+                "name": "EXCiSiON",
+                "score": 0
+            },
+            {
+                "format": 348,
+                "name": "Unwanted x265 Groups",
+                "score": 0
+            },
+            {
+                "format": 347,
+                "name": "CRX",
+                "score": 0
+            },
+            {
+                "format": 346,
+                "name": "HDR10 (Missing) (x265 HDR only)",
+                "score": 0
+            },
+            {
+                "format": 345,
+                "name": "UHD Bluray",
+                "score": 0
+            },
+            {
                 "format": 344,
                 "name": "jennaortegaUHD",
                 "score": 0

--- a/imports/quality_profiles/radarr/1080p Balanced (radarr - master).json
+++ b/imports/quality_profiles/radarr/1080p Balanced (radarr - master).json
@@ -367,6 +367,46 @@
         "cutoffFormatScore": 500,
         "formatItems": [
             {
+                "format": 353,
+                "name": "BHDStudio (1080p x265)",
+                "score": 0
+            },
+            {
+                "format": 352,
+                "name": "E1",
+                "score": 0
+            },
+            {
+                "format": 351,
+                "name": "2160p x265",
+                "score": 0
+            },
+            {
+                "format": 349,
+                "name": "EXCiSiON",
+                "score": 0
+            },
+            {
+                "format": 348,
+                "name": "Unwanted x265 Groups",
+                "score": 0
+            },
+            {
+                "format": 347,
+                "name": "CRX",
+                "score": 0
+            },
+            {
+                "format": 346,
+                "name": "HDR10 (Missing) (x265 HDR only)",
+                "score": 0
+            },
+            {
+                "format": 345,
+                "name": "UHD Bluray",
+                "score": 0
+            },
+            {
                 "format": 344,
                 "name": "jennaortegaUHD",
                 "score": 0

--- a/imports/quality_profiles/radarr/1080p Optimal (Single Grab) (radarr - master).json
+++ b/imports/quality_profiles/radarr/1080p Optimal (Single Grab) (radarr - master).json
@@ -360,6 +360,46 @@
         "cutoffFormatScore": 0,
         "formatItems": [
             {
+                "format": 353,
+                "name": "BHDStudio (1080p x265)",
+                "score": 0
+            },
+            {
+                "format": 352,
+                "name": "E1",
+                "score": 0
+            },
+            {
+                "format": 351,
+                "name": "2160p x265",
+                "score": 0
+            },
+            {
+                "format": 349,
+                "name": "EXCiSiON",
+                "score": 0
+            },
+            {
+                "format": 348,
+                "name": "Unwanted x265 Groups",
+                "score": 0
+            },
+            {
+                "format": 347,
+                "name": "CRX",
+                "score": 0
+            },
+            {
+                "format": 346,
+                "name": "HDR10 (Missing) (x265 HDR only)",
+                "score": 0
+            },
+            {
+                "format": 345,
+                "name": "UHD Bluray",
+                "score": 0
+            },
+            {
                 "format": 344,
                 "name": "jennaortegaUHD",
                 "score": 0

--- a/imports/quality_profiles/radarr/1080p Optimal (radarr - master).json
+++ b/imports/quality_profiles/radarr/1080p Optimal (radarr - master).json
@@ -360,6 +360,46 @@
         "cutoffFormatScore": 1000,
         "formatItems": [
             {
+                "format": 353,
+                "name": "BHDStudio (1080p x265)",
+                "score": 0
+            },
+            {
+                "format": 352,
+                "name": "E1",
+                "score": 0
+            },
+            {
+                "format": 351,
+                "name": "2160p x265",
+                "score": 0
+            },
+            {
+                "format": 349,
+                "name": "EXCiSiON",
+                "score": 0
+            },
+            {
+                "format": 348,
+                "name": "Unwanted x265 Groups",
+                "score": 0
+            },
+            {
+                "format": 347,
+                "name": "CRX",
+                "score": 0
+            },
+            {
+                "format": 346,
+                "name": "HDR10 (Missing) (x265 HDR only)",
+                "score": 0
+            },
+            {
+                "format": 345,
+                "name": "UHD Bluray",
+                "score": 0
+            },
+            {
                 "format": 344,
                 "name": "jennaortegaUHD",
                 "score": 0

--- a/imports/quality_profiles/radarr/1080p Transparent (Double Grab) (radarr - master).json
+++ b/imports/quality_profiles/radarr/1080p Transparent (Double Grab) (radarr - master).json
@@ -367,6 +367,46 @@
         "cutoffFormatScore": 140,
         "formatItems": [
             {
+                "format": 353,
+                "name": "BHDStudio (1080p x265)",
+                "score": 0
+            },
+            {
+                "format": 352,
+                "name": "E1",
+                "score": 0
+            },
+            {
+                "format": 351,
+                "name": "2160p x265",
+                "score": 0
+            },
+            {
+                "format": 349,
+                "name": "EXCiSiON",
+                "score": 0
+            },
+            {
+                "format": 348,
+                "name": "Unwanted x265 Groups",
+                "score": 0
+            },
+            {
+                "format": 347,
+                "name": "CRX",
+                "score": 0
+            },
+            {
+                "format": 346,
+                "name": "HDR10 (Missing) (x265 HDR only)",
+                "score": 0
+            },
+            {
+                "format": 345,
+                "name": "UHD Bluray",
+                "score": 0
+            },
+            {
                 "format": 344,
                 "name": "jennaortegaUHD",
                 "score": 0

--- a/imports/quality_profiles/radarr/1080p Transparent (Single Grab) (radarr - master).json
+++ b/imports/quality_profiles/radarr/1080p Transparent (Single Grab) (radarr - master).json
@@ -367,6 +367,46 @@
         "cutoffFormatScore": 0,
         "formatItems": [
             {
+                "format": 353,
+                "name": "BHDStudio (1080p x265)",
+                "score": 0
+            },
+            {
+                "format": 352,
+                "name": "E1",
+                "score": 0
+            },
+            {
+                "format": 351,
+                "name": "2160p x265",
+                "score": 0
+            },
+            {
+                "format": 349,
+                "name": "EXCiSiON",
+                "score": 0
+            },
+            {
+                "format": 348,
+                "name": "Unwanted x265 Groups",
+                "score": 0
+            },
+            {
+                "format": 347,
+                "name": "CRX",
+                "score": 0
+            },
+            {
+                "format": 346,
+                "name": "HDR10 (Missing) (x265 HDR only)",
+                "score": 0
+            },
+            {
+                "format": 345,
+                "name": "UHD Bluray",
+                "score": 0
+            },
+            {
                 "format": 344,
                 "name": "jennaortegaUHD",
                 "score": 0

--- a/imports/quality_profiles/radarr/1080p h265 Balanced (Single Grab) (radarr - master).json
+++ b/imports/quality_profiles/radarr/1080p h265 Balanced (Single Grab) (radarr - master).json
@@ -367,6 +367,46 @@
         "cutoffFormatScore": 0,
         "formatItems": [
             {
+                "format": 353,
+                "name": "BHDStudio (1080p x265)",
+                "score": 0
+            },
+            {
+                "format": 352,
+                "name": "E1",
+                "score": 0
+            },
+            {
+                "format": 351,
+                "name": "2160p x265",
+                "score": 0
+            },
+            {
+                "format": 349,
+                "name": "EXCiSiON",
+                "score": 0
+            },
+            {
+                "format": 348,
+                "name": "Unwanted x265 Groups",
+                "score": 0
+            },
+            {
+                "format": 347,
+                "name": "CRX",
+                "score": 0
+            },
+            {
+                "format": 346,
+                "name": "HDR10 (Missing) (x265 HDR only)",
+                "score": 0
+            },
+            {
+                "format": 345,
+                "name": "UHD Bluray",
+                "score": 0
+            },
+            {
                 "format": 344,
                 "name": "jennaortegaUHD",
                 "score": 0

--- a/imports/quality_profiles/radarr/1080p h265 Balanced (radarr - master).json
+++ b/imports/quality_profiles/radarr/1080p h265 Balanced (radarr - master).json
@@ -228,6 +228,17 @@
                 "id": 1005
             },
             {
+                "quality": {
+                    "id": 30,
+                    "name": "Remux-1080p",
+                    "source": "bluray",
+                    "resolution": 1080,
+                    "modifier": "remux"
+                },
+                "items": [],
+                "allowed": false
+            },
+            {
                 "name": "Balanced Capable",
                 "items": [
                     {
@@ -266,17 +277,6 @@
                 ],
                 "allowed": true,
                 "id": 1004
-            },
-            {
-                "quality": {
-                    "id": 30,
-                    "name": "Remux-1080p",
-                    "source": "bluray",
-                    "resolution": 1080,
-                    "modifier": "remux"
-                },
-                "items": [],
-                "allowed": false
             },
             {
                 "quality": {
@@ -366,6 +366,46 @@
         "minFormatScore": 0,
         "cutoffFormatScore": 1000,
         "formatItems": [
+            {
+                "format": 353,
+                "name": "BHDStudio (1080p x265)",
+                "score": 0
+            },
+            {
+                "format": 352,
+                "name": "E1",
+                "score": 0
+            },
+            {
+                "format": 351,
+                "name": "2160p x265",
+                "score": 0
+            },
+            {
+                "format": 349,
+                "name": "EXCiSiON",
+                "score": 0
+            },
+            {
+                "format": 348,
+                "name": "Unwanted x265 Groups",
+                "score": 0
+            },
+            {
+                "format": 347,
+                "name": "CRX",
+                "score": 0
+            },
+            {
+                "format": 346,
+                "name": "HDR10 (Missing) (x265 HDR only)",
+                "score": 0
+            },
+            {
+                "format": 345,
+                "name": "UHD Bluray",
+                "score": 0
+            },
             {
                 "format": 344,
                 "name": "jennaortegaUHD",

--- a/imports/quality_profiles/radarr/1080p x265 HDR Transparent (radarr - master).json
+++ b/imports/quality_profiles/radarr/1080p x265 HDR Transparent (radarr - master).json
@@ -1,0 +1,1105 @@
+[
+    {
+        "name": "1080p x265 HDR Transparent",
+        "upgradeAllowed": true,
+        "cutoff": 1002,
+        "items": [
+            {
+                "quality": {
+                    "id": 24,
+                    "name": "WORKPRINT",
+                    "source": "workprint",
+                    "resolution": 0,
+                    "modifier": "none"
+                },
+                "items": [],
+                "allowed": false
+            },
+            {
+                "quality": {
+                    "id": 29,
+                    "name": "REGIONAL",
+                    "source": "dvd",
+                    "resolution": 480,
+                    "modifier": "regional"
+                },
+                "items": [],
+                "allowed": false
+            },
+            {
+                "quality": {
+                    "id": 4,
+                    "name": "HDTV-720p",
+                    "source": "tv",
+                    "resolution": 720,
+                    "modifier": "none"
+                },
+                "items": [],
+                "allowed": false
+            },
+            {
+                "name": "WEB 720p",
+                "items": [
+                    {
+                        "quality": {
+                            "id": 5,
+                            "name": "WEBDL-720p",
+                            "source": "webdl",
+                            "resolution": 720,
+                            "modifier": "none"
+                        },
+                        "items": [],
+                        "allowed": false
+                    },
+                    {
+                        "quality": {
+                            "id": 14,
+                            "name": "WEBRip-720p",
+                            "source": "webrip",
+                            "resolution": 720,
+                            "modifier": "none"
+                        },
+                        "items": [],
+                        "allowed": false
+                    }
+                ],
+                "allowed": false,
+                "id": 1001
+            },
+            {
+                "quality": {
+                    "id": 6,
+                    "name": "Bluray-720p",
+                    "source": "bluray",
+                    "resolution": 720,
+                    "modifier": "none"
+                },
+                "items": [],
+                "allowed": false
+            },
+            {
+                "quality": {
+                    "id": 1,
+                    "name": "SDTV",
+                    "source": "tv",
+                    "resolution": 480,
+                    "modifier": "none"
+                },
+                "items": [],
+                "allowed": false
+            },
+            {
+                "quality": {
+                    "id": 20,
+                    "name": "Bluray-480p",
+                    "source": "bluray",
+                    "resolution": 480,
+                    "modifier": "none"
+                },
+                "items": [],
+                "allowed": false
+            },
+            {
+                "quality": {
+                    "id": 21,
+                    "name": "Bluray-576p",
+                    "source": "bluray",
+                    "resolution": 576,
+                    "modifier": "none"
+                },
+                "items": [],
+                "allowed": false
+            },
+            {
+                "quality": {
+                    "id": 23,
+                    "name": "DVD-R",
+                    "source": "dvd",
+                    "resolution": 480,
+                    "modifier": "remux"
+                },
+                "items": [],
+                "allowed": false
+            },
+            {
+                "name": "CAM",
+                "items": [
+                    {
+                        "quality": {
+                            "id": 25,
+                            "name": "CAM",
+                            "source": "cam",
+                            "resolution": 0,
+                            "modifier": "none"
+                        },
+                        "items": [],
+                        "allowed": true
+                    },
+                    {
+                        "quality": {
+                            "id": 26,
+                            "name": "TELESYNC",
+                            "source": "telesync",
+                            "resolution": 0,
+                            "modifier": "none"
+                        },
+                        "items": [],
+                        "allowed": true
+                    },
+                    {
+                        "quality": {
+                            "id": 27,
+                            "name": "TELECINE",
+                            "source": "telecine",
+                            "resolution": 0,
+                            "modifier": "none"
+                        },
+                        "items": [],
+                        "allowed": true
+                    }
+                ],
+                "allowed": true,
+                "id": 1004
+            },
+            {
+                "quality": {
+                    "id": 0,
+                    "name": "Unknown",
+                    "source": "unknown",
+                    "resolution": 0,
+                    "modifier": "none"
+                },
+                "items": [],
+                "allowed": true
+            },
+            {
+                "name": "DVD",
+                "items": [
+                    {
+                        "quality": {
+                            "id": 28,
+                            "name": "DVDSCR",
+                            "source": "dvd",
+                            "resolution": 480,
+                            "modifier": "screener"
+                        },
+                        "items": [],
+                        "allowed": false
+                    },
+                    {
+                        "quality": {
+                            "id": 12,
+                            "name": "WEBRip-480p",
+                            "source": "webrip",
+                            "resolution": 480,
+                            "modifier": "none"
+                        },
+                        "items": [],
+                        "allowed": false
+                    },
+                    {
+                        "quality": {
+                            "id": 2,
+                            "name": "DVD",
+                            "source": "dvd",
+                            "resolution": 0,
+                            "modifier": "none"
+                        },
+                        "items": [],
+                        "allowed": true
+                    },
+                    {
+                        "quality": {
+                            "id": 8,
+                            "name": "WEBDL-480p",
+                            "source": "webdl",
+                            "resolution": 480,
+                            "modifier": "none"
+                        },
+                        "items": [],
+                        "allowed": true
+                    }
+                ],
+                "allowed": true,
+                "id": 1003
+            },
+            {
+                "quality": {
+                    "id": 9,
+                    "name": "HDTV-1080p",
+                    "source": "tv",
+                    "resolution": 1080,
+                    "modifier": "none"
+                },
+                "items": [],
+                "allowed": true
+            },
+            {
+                "name": "Transparent Capable",
+                "items": [
+                    {
+                        "quality": {
+                            "id": 3,
+                            "name": "WEBDL-1080p",
+                            "source": "webdl",
+                            "resolution": 1080,
+                            "modifier": "none"
+                        },
+                        "items": [],
+                        "allowed": true
+                    },
+                    {
+                        "quality": {
+                            "id": 15,
+                            "name": "WEBRip-1080p",
+                            "source": "webrip",
+                            "resolution": 1080,
+                            "modifier": "none"
+                        },
+                        "items": [],
+                        "allowed": true
+                    },
+                    {
+                        "quality": {
+                            "id": 7,
+                            "name": "Bluray-1080p",
+                            "source": "bluray",
+                            "resolution": 1080,
+                            "modifier": "none"
+                        },
+                        "items": [],
+                        "allowed": true
+                    }
+                ],
+                "allowed": true,
+                "id": 1002
+            },
+            {
+                "quality": {
+                    "id": 30,
+                    "name": "Remux-1080p",
+                    "source": "bluray",
+                    "resolution": 1080,
+                    "modifier": "remux"
+                },
+                "items": [],
+                "allowed": false
+            },
+            {
+                "quality": {
+                    "id": 16,
+                    "name": "HDTV-2160p",
+                    "source": "tv",
+                    "resolution": 2160,
+                    "modifier": "none"
+                },
+                "items": [],
+                "allowed": false
+            },
+            {
+                "quality": {
+                    "id": 18,
+                    "name": "WEBDL-2160p",
+                    "source": "webdl",
+                    "resolution": 2160,
+                    "modifier": "none"
+                },
+                "items": [],
+                "allowed": false
+            },
+            {
+                "quality": {
+                    "id": 17,
+                    "name": "WEBRip-2160p",
+                    "source": "webrip",
+                    "resolution": 2160,
+                    "modifier": "none"
+                },
+                "items": [],
+                "allowed": false
+            },
+            {
+                "quality": {
+                    "id": 19,
+                    "name": "Bluray-2160p",
+                    "source": "bluray",
+                    "resolution": 2160,
+                    "modifier": "none"
+                },
+                "items": [],
+                "allowed": false
+            },
+            {
+                "quality": {
+                    "id": 31,
+                    "name": "Remux-2160p",
+                    "source": "bluray",
+                    "resolution": 2160,
+                    "modifier": "remux"
+                },
+                "items": [],
+                "allowed": false
+            },
+            {
+                "quality": {
+                    "id": 22,
+                    "name": "BR-DISK",
+                    "source": "bluray",
+                    "resolution": 1080,
+                    "modifier": "brdisk"
+                },
+                "items": [],
+                "allowed": false
+            },
+            {
+                "quality": {
+                    "id": 10,
+                    "name": "Raw-HD",
+                    "source": "tv",
+                    "resolution": 1080,
+                    "modifier": "rawhd"
+                },
+                "items": [],
+                "allowed": false
+            }
+        ],
+        "minFormatScore": 0,
+        "cutoffFormatScore": 500,
+        "formatItems": [
+            {
+                "format": 352,
+                "name": "E1",
+                "score": 70
+            },
+            {
+                "format": 351,
+                "name": "2160p x265",
+                "score": -9999
+            },
+            {
+                "format": 349,
+                "name": "EXCiSiON",
+                "score": 70
+            },
+            {
+                "format": 348,
+                "name": "Unwanted x265 Groups",
+                "score": -9999
+            },
+            {
+                "format": 347,
+                "name": "CRX",
+                "score": 70
+            },
+            {
+                "format": 346,
+                "name": "HDR10 (Missing) (x265 HDR only)",
+                "score": 10
+            },
+            {
+                "format": 345,
+                "name": "UHD Bluray",
+                "score": 350
+            },
+            {
+                "format": 344,
+                "name": "jennaortegaUHD",
+                "score": 0
+            },
+            {
+                "format": 342,
+                "name": "Freeleech25",
+                "score": 0
+            },
+            {
+                "format": 341,
+                "name": "Freeleech50",
+                "score": 0
+            },
+            {
+                "format": 340,
+                "name": "Freeleech75",
+                "score": 0
+            },
+            {
+                "format": 339,
+                "name": "Freeleech100",
+                "score": 0
+            },
+            {
+                "format": 338,
+                "name": "TEST FLAC",
+                "score": 0
+            },
+            {
+                "format": 337,
+                "name": "h265 (4k)",
+                "score": 0
+            },
+            {
+                "format": 336,
+                "name": "MAX",
+                "score": 0
+            },
+            {
+                "format": 335,
+                "name": "Blu-Ray (Remux)",
+                "score": -9999
+            },
+            {
+                "format": 334,
+                "name": "PCM",
+                "score": 0
+            },
+            {
+                "format": 333,
+                "name": "h265",
+                "score": -9999
+            },
+            {
+                "format": 331,
+                "name": "Golden Popcorn 720p",
+                "score": 0
+            },
+            {
+                "format": 330,
+                "name": "LQ",
+                "score": -9999
+            },
+            {
+                "format": 329,
+                "name": "EPSiLON",
+                "score": 0
+            },
+            {
+                "format": 328,
+                "name": "playBD",
+                "score": 0
+            },
+            {
+                "format": 327,
+                "name": "BLURANiUM",
+                "score": 0
+            },
+            {
+                "format": 326,
+                "name": "PmP",
+                "score": 0
+            },
+            {
+                "format": 325,
+                "name": "WiLDCAT",
+                "score": 0
+            },
+            {
+                "format": 324,
+                "name": "TRiToN",
+                "score": 0
+            },
+            {
+                "format": 323,
+                "name": "3L",
+                "score": 0
+            },
+            {
+                "format": 322,
+                "name": "Dolby Vision w/out Fallback",
+                "score": -9999
+            },
+            {
+                "format": 321,
+                "name": "UHDBits",
+                "score": -9999
+            },
+            {
+                "format": 318,
+                "name": "ATMOS (Missing)",
+                "score": 0
+            },
+            {
+                "format": 317,
+                "name": "TrueHD (Missing)",
+                "score": 0
+            },
+            {
+                "format": 316,
+                "name": "HDR10 (Missing)",
+                "score": 10
+            },
+            {
+                "format": 315,
+                "name": "HDR10",
+                "score": 10
+            },
+            {
+                "format": 314,
+                "name": "Dolby Vision",
+                "score": 30
+            },
+            {
+                "format": 312,
+                "name": "HDR10+",
+                "score": 20
+            },
+            {
+                "format": 308,
+                "name": "Stream Optimised",
+                "score": 0
+            },
+            {
+                "format": 307,
+                "name": "LoRD",
+                "score": 70
+            },
+            {
+                "format": 306,
+                "name": "Scene",
+                "score": 30
+            },
+            {
+                "format": 303,
+                "name": "mHD",
+                "score": -99999
+            },
+            {
+                "format": 302,
+                "name": "AV-1",
+                "score": -9999
+            },
+            {
+                "format": 301,
+                "name": "VVC",
+                "score": -9999
+            },
+            {
+                "format": 300,
+                "name": "Extras",
+                "score": -9999
+            },
+            {
+                "format": 298,
+                "name": "480p",
+                "score": 0
+            },
+            {
+                "format": 297,
+                "name": "Dariush ",
+                "score": 20
+            },
+            {
+                "format": 296,
+                "name": "TBB SD",
+                "score": 30
+            },
+            {
+                "format": 295,
+                "name": "Xvid",
+                "score": 0
+            },
+            {
+                "format": 294,
+                "name": "DVD",
+                "score": 0
+            },
+            {
+                "format": 293,
+                "name": "DVD REMUX ",
+                "score": 40
+            },
+            {
+                "format": 292,
+                "name": "HANDJOB SD",
+                "score": 20
+            },
+            {
+                "format": 291,
+                "name": "iTunes (Missing)",
+                "score": 20
+            },
+            {
+                "format": 290,
+                "name": "ROKU",
+                "score": 30
+            },
+            {
+                "format": 289,
+                "name": "BeyondHD",
+                "score": -10000
+            },
+            {
+                "format": 288,
+                "name": "Disc ",
+                "score": -9999
+            },
+            {
+                "format": 287,
+                "name": "3D",
+                "score": -9999
+            },
+            {
+                "format": 286,
+                "name": "Unwanted",
+                "score": -9999
+            },
+            {
+                "format": 285,
+                "name": "HDBits Internal",
+                "score": 70
+            },
+            {
+                "format": 284,
+                "name": "RightSIZE",
+                "score": 70
+            },
+            {
+                "format": 283,
+                "name": "Black and White",
+                "score": -9999
+            },
+            {
+                "format": 281,
+                "name": "TrueHD",
+                "score": 0
+            },
+            {
+                "format": 280,
+                "name": "DTS-X",
+                "score": 0
+            },
+            {
+                "format": 279,
+                "name": "FLAC",
+                "score": 0
+            },
+            {
+                "format": 278,
+                "name": "DTS-HD MA",
+                "score": 0
+            },
+            {
+                "format": 276,
+                "name": "x265",
+                "score": -90
+            },
+            {
+                "format": 275,
+                "name": "Golden Popcorn SD",
+                "score": 30
+            },
+            {
+                "format": 274,
+                "name": "Golden Popcorn 1080p",
+                "score": 120
+            },
+            {
+                "format": 273,
+                "name": "IMAX",
+                "score": 10
+            },
+            {
+                "format": 272,
+                "name": "ATMOS",
+                "score": 5
+            },
+            {
+                "format": 271,
+                "name": "DD",
+                "score": 0
+            },
+            {
+                "format": 270,
+                "name": "DTS",
+                "score": 0
+            },
+            {
+                "format": 269,
+                "name": "DD+",
+                "score": 0
+            },
+            {
+                "format": 268,
+                "name": "iTunes",
+                "score": 20
+            },
+            {
+                "format": 267,
+                "name": "Paramount+",
+                "score": 30
+            },
+            {
+                "format": 266,
+                "name": "Peacock TV",
+                "score": 30
+            },
+            {
+                "format": 265,
+                "name": "Hulu",
+                "score": 30
+            },
+            {
+                "format": 264,
+                "name": "Netflix",
+                "score": 40
+            },
+            {
+                "format": 263,
+                "name": "HBO Max",
+                "score": 40
+            },
+            {
+                "format": 262,
+                "name": "Disney+",
+                "score": 40
+            },
+            {
+                "format": 261,
+                "name": "Apple TV+",
+                "score": 50
+            },
+            {
+                "format": 260,
+                "name": "Movies Anywhere",
+                "score": 60
+            },
+            {
+                "format": 259,
+                "name": "Amazon Prime",
+                "score": 50
+            },
+            {
+                "format": 258,
+                "name": "REMUX",
+                "score": -9999
+            },
+            {
+                "format": 256,
+                "name": "x264",
+                "score": 10
+            },
+            {
+                "format": 255,
+                "name": "WEBRip",
+                "score": 0
+            },
+            {
+                "format": 254,
+                "name": "Blu-Ray",
+                "score": 0
+            },
+            {
+                "format": 253,
+                "name": "2160p",
+                "score": -9999
+            },
+            {
+                "format": 252,
+                "name": "720p",
+                "score": -10000
+            },
+            {
+                "format": 250,
+                "name": "1080p",
+                "score": 60
+            },
+            {
+                "format": 249,
+                "name": "BHDStudio",
+                "score": 30
+            },
+            {
+                "format": 248,
+                "name": "LEGi0N",
+                "score": 30
+            },
+            {
+                "format": 247,
+                "name": "FraMeSToR",
+                "score": 30
+            },
+            {
+                "format": 246,
+                "name": "iFT",
+                "score": 70
+            },
+            {
+                "format": 245,
+                "name": "MTeam",
+                "score": -9999
+            },
+            {
+                "format": 244,
+                "name": "EDPH",
+                "score": 30
+            },
+            {
+                "format": 243,
+                "name": "HANDJOB",
+                "score": 30
+            },
+            {
+                "format": 242,
+                "name": "c0ke",
+                "score": 110
+            },
+            {
+                "format": 241,
+                "name": "KASHMiR",
+                "score": 70
+            },
+            {
+                "format": 240,
+                "name": "WMING",
+                "score": 70
+            },
+            {
+                "format": 239,
+                "name": "playHD",
+                "score": 70
+            },
+            {
+                "format": 238,
+                "name": "E.N.D",
+                "score": 70
+            },
+            {
+                "format": 237,
+                "name": "GutS",
+                "score": 70
+            },
+            {
+                "format": 236,
+                "name": "BV",
+                "score": 70
+            },
+            {
+                "format": 235,
+                "name": "SiMPLE",
+                "score": 70
+            },
+            {
+                "format": 234,
+                "name": "W4NK3R",
+                "score": 70
+            },
+            {
+                "format": 233,
+                "name": "GS88",
+                "score": 70
+            },
+            {
+                "format": 232,
+                "name": "HiP",
+                "score": 80
+            },
+            {
+                "format": 231,
+                "name": "GALAXY",
+                "score": 70
+            },
+            {
+                "format": 230,
+                "name": "luvBB",
+                "score": 70
+            },
+            {
+                "format": 229,
+                "name": "NyHD",
+                "score": 70
+            },
+            {
+                "format": 228,
+                "name": "ZIMBO",
+                "score": 70
+            },
+            {
+                "format": 227,
+                "name": "ThD",
+                "score": 70
+            },
+            {
+                "format": 226,
+                "name": "SaNcTi",
+                "score": 70
+            },
+            {
+                "format": 225,
+                "name": "ORiGEN",
+                "score": 70
+            },
+            {
+                "format": 224,
+                "name": "Positive",
+                "score": 70
+            },
+            {
+                "format": 223,
+                "name": "ESiR",
+                "score": 70
+            },
+            {
+                "format": 222,
+                "name": "Chotab",
+                "score": 70
+            },
+            {
+                "format": 221,
+                "name": "xander",
+                "score": 70
+            },
+            {
+                "format": 220,
+                "name": "FTW-HD",
+                "score": 70
+            },
+            {
+                "format": 219,
+                "name": "Penumbra",
+                "score": 70
+            },
+            {
+                "format": 218,
+                "name": "TDD",
+                "score": 70
+            },
+            {
+                "format": 217,
+                "name": "Dariush SD",
+                "score": 70
+            },
+            {
+                "format": 216,
+                "name": "PTer",
+                "score": 70
+            },
+            {
+                "format": 215,
+                "name": "SbR",
+                "score": 70
+            },
+            {
+                "format": 214,
+                "name": "nmd",
+                "score": 70
+            },
+            {
+                "format": 213,
+                "name": "TBB",
+                "score": 70
+            },
+            {
+                "format": 212,
+                "name": "EA",
+                "score": 80
+            },
+            {
+                "format": 211,
+                "name": "BMF",
+                "score": 80
+            },
+            {
+                "format": 210,
+                "name": "LolHD",
+                "score": 80
+            },
+            {
+                "format": 209,
+                "name": "HDMaNiAcS",
+                "score": 80
+            },
+            {
+                "format": 208,
+                "name": "IDE",
+                "score": 80
+            },
+            {
+                "format": 207,
+                "name": "de[42]",
+                "score": 90
+            },
+            {
+                "format": 206,
+                "name": "NCmt",
+                "score": 100
+            },
+            {
+                "format": 205,
+                "name": "decibeL",
+                "score": 90
+            },
+            {
+                "format": 204,
+                "name": "NTb",
+                "score": 80
+            },
+            {
+                "format": 203,
+                "name": "CRiSC",
+                "score": 90
+            },
+            {
+                "format": 202,
+                "name": "SA89",
+                "score": 100
+            },
+            {
+                "format": 201,
+                "name": "HiDt",
+                "score": 100
+            },
+            {
+                "format": 200,
+                "name": "FoRM",
+                "score": 100
+            },
+            {
+                "format": 199,
+                "name": "HiFi",
+                "score": 100
+            },
+            {
+                "format": 198,
+                "name": "CtrlHD",
+                "score": 100
+            },
+            {
+                "format": 197,
+                "name": "VietHD",
+                "score": 110
+            },
+            {
+                "format": 196,
+                "name": "ZQ",
+                "score": 110
+            },
+            {
+                "format": 195,
+                "name": "TayTo",
+                "score": 110
+            },
+            {
+                "format": 194,
+                "name": "Geek",
+                "score": 110
+            },
+            {
+                "format": 193,
+                "name": "EbP",
+                "score": 120
+            },
+            {
+                "format": 192,
+                "name": "DON",
+                "score": 120
+            },
+            {
+                "format": 191,
+                "name": "D-Z0N3",
+                "score": 120
+            }
+        ],
+        "language": {
+            "id": -1,
+            "name": "Any"
+        }
+    }
+]

--- a/imports/quality_profiles/radarr/1080p x265 HDR Transparent (radarr - master).json
+++ b/imports/quality_profiles/radarr/1080p x265 HDR Transparent (radarr - master).json
@@ -367,6 +367,11 @@
         "cutoffFormatScore": 500,
         "formatItems": [
             {
+                "format": 353,
+                "name": "BHDStudio (1080p x265)",
+                "score": -9999
+            },
+            {
                 "format": 352,
                 "name": "E1",
                 "score": 70

--- a/imports/quality_profiles/radarr/2160p Balanced (radarr - master).json
+++ b/imports/quality_profiles/radarr/2160p Balanced (radarr - master).json
@@ -1,6 +1,6 @@
 [
     {
-        "name": "1080p Transparent",
+        "name": "2160p Balanced",
         "upgradeAllowed": true,
         "cutoff": 1002,
         "items": [
@@ -235,7 +235,7 @@
                 "allowed": true
             },
             {
-                "name": "Transparent Capable",
+                "name": "Balanced Capable",
                 "items": [
                     {
                         "quality": {
@@ -269,10 +269,32 @@
                         },
                         "items": [],
                         "allowed": true
+                    },
+                    {
+                        "quality": {
+                            "id": 18,
+                            "name": "WEBDL-2160p",
+                            "source": "webdl",
+                            "resolution": 2160,
+                            "modifier": "none"
+                        },
+                        "items": [],
+                        "allowed": false
                     }
                 ],
                 "allowed": true,
                 "id": 1002
+            },
+            {
+                "quality": {
+                    "id": 19,
+                    "name": "Bluray-2160p",
+                    "source": "bluray",
+                    "resolution": 2160,
+                    "modifier": "none"
+                },
+                "items": [],
+                "allowed": false
             },
             {
                 "quality": {
@@ -298,31 +320,9 @@
             },
             {
                 "quality": {
-                    "id": 18,
-                    "name": "WEBDL-2160p",
-                    "source": "webdl",
-                    "resolution": 2160,
-                    "modifier": "none"
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "quality": {
                     "id": 17,
                     "name": "WEBRip-2160p",
                     "source": "webrip",
-                    "resolution": 2160,
-                    "modifier": "none"
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "quality": {
-                    "id": 19,
-                    "name": "Bluray-2160p",
-                    "source": "bluray",
                     "resolution": 2160,
                     "modifier": "none"
                 },
@@ -364,7 +364,7 @@
             }
         ],
         "minFormatScore": 0,
-        "cutoffFormatScore": 500,
+        "cutoffFormatScore": 1000,
         "formatItems": [
             {
                 "format": 353,
@@ -439,12 +439,12 @@
             {
                 "format": 337,
                 "name": "h265 (4k)",
-                "score": 0
+                "score": 120
             },
             {
                 "format": 336,
                 "name": "MAX",
-                "score": 0
+                "score": 40
             },
             {
                 "format": 335,
@@ -519,7 +519,7 @@
             {
                 "format": 318,
                 "name": "ATMOS (Missing)",
-                "score": 0
+                "score": 10
             },
             {
                 "format": 317,
@@ -529,22 +529,22 @@
             {
                 "format": 316,
                 "name": "HDR10 (Missing)",
-                "score": -9999
+                "score": 10
             },
             {
                 "format": 315,
                 "name": "HDR10",
-                "score": -9999
+                "score": 10
             },
             {
                 "format": 314,
                 "name": "Dolby Vision",
-                "score": -9999
+                "score": 30
             },
             {
                 "format": 312,
                 "name": "HDR10+",
-                "score": -9999
+                "score": 20
             },
             {
                 "format": 308,
@@ -559,7 +559,7 @@
             {
                 "format": 306,
                 "name": "Scene",
-                "score": 30
+                "score": -9999
             },
             {
                 "format": 303,
@@ -704,7 +704,7 @@
             {
                 "format": 272,
                 "name": "ATMOS",
-                "score": 5
+                "score": 10
             },
             {
                 "format": 271,
@@ -794,7 +794,7 @@
             {
                 "format": 253,
                 "name": "2160p",
-                "score": -9999
+                "score": 120
             },
             {
                 "format": 252,

--- a/imports/quality_profiles/radarr/2160p Optimal (Single Grab) (radarr - master).json
+++ b/imports/quality_profiles/radarr/2160p Optimal (Single Grab) (radarr - master).json
@@ -360,6 +360,46 @@
         "cutoffFormatScore": 0,
         "formatItems": [
             {
+                "format": 353,
+                "name": "BHDStudio (1080p x265)",
+                "score": 0
+            },
+            {
+                "format": 352,
+                "name": "E1",
+                "score": 0
+            },
+            {
+                "format": 351,
+                "name": "2160p x265",
+                "score": 0
+            },
+            {
+                "format": 349,
+                "name": "EXCiSiON",
+                "score": 0
+            },
+            {
+                "format": 348,
+                "name": "Unwanted x265 Groups",
+                "score": 0
+            },
+            {
+                "format": 347,
+                "name": "CRX",
+                "score": 0
+            },
+            {
+                "format": 346,
+                "name": "HDR10 (Missing) (x265 HDR only)",
+                "score": 0
+            },
+            {
+                "format": 345,
+                "name": "UHD Bluray",
+                "score": 0
+            },
+            {
                 "format": 344,
                 "name": "jennaortegaUHD",
                 "score": -9999

--- a/imports/quality_profiles/radarr/2160p Optimal (radarr - master).json
+++ b/imports/quality_profiles/radarr/2160p Optimal (radarr - master).json
@@ -360,6 +360,46 @@
         "cutoffFormatScore": 320,
         "formatItems": [
             {
+                "format": 353,
+                "name": "BHDStudio (1080p x265)",
+                "score": 0
+            },
+            {
+                "format": 352,
+                "name": "E1",
+                "score": 0
+            },
+            {
+                "format": 351,
+                "name": "2160p x265",
+                "score": 0
+            },
+            {
+                "format": 349,
+                "name": "EXCiSiON",
+                "score": 0
+            },
+            {
+                "format": 348,
+                "name": "Unwanted x265 Groups",
+                "score": 0
+            },
+            {
+                "format": 347,
+                "name": "CRX",
+                "score": 0
+            },
+            {
+                "format": 346,
+                "name": "HDR10 (Missing) (x265 HDR only)",
+                "score": 0
+            },
+            {
+                "format": 345,
+                "name": "UHD Bluray",
+                "score": 0
+            },
+            {
                 "format": 344,
                 "name": "jennaortegaUHD",
                 "score": -99999


### PR DESCRIPTION
Implemented and tested 1080p x265 HDR.
- Priority on transparent HDR encodes from a UHD source.
- Fallbacks to x264 Transparent -> SD.
- No 2160p fallback for now