### PR TITLE
Feature/265 whitelist

### DIFF
--- a/imports/custom_formats/radarr/custom formats (radarr - master).json
+++ b/imports/custom_formats/radarr/custom formats (radarr - master).json
@@ -12395,221 +12395,214 @@
     "name": "h265",
     "includeCustomFormatWhenRenaming": false,
     "specifications": [
-      {
-        "name": "h265",
-        "implementation": "ReleaseTitleSpecification",
-        "implementationName": "Release Title",
-        "infoLink": "https://wiki.servarr.com/radarr/settings#custom-formats-2",
-        "negate": false,
-        "required": true,
-        "fields": [
-          {
-            "order": 0,
-            "name": "value",
-            "label": "Regular Expression",
-            "helpText": "Custom Format RegEx is Case Insensitive",
-            "value": "(?i)h\\s*\\.?\\s*265",
-            "type": "textbox",
-            "advanced": false,
-            "privacy": "normal",
-            "isFloat": false
-          }
-        ]
-      },
-      {
-        "name": "Disc",
-        "implementation": "ReleaseTitleSpecification",
-        "implementationName": "Release Title",
-        "infoLink": "https://wiki.servarr.com/radarr/settings#custom-formats-2",
-        "negate": true,
-        "required": true,
-        "fields": [
-          {
-            "order": 0,
-            "name": "value",
-            "label": "Regular Expression",
-            "helpText": "Custom Format RegEx is Case Insensitive",
-            "value": "^(?!.*\\b((?<!HD[._ -]|HD)DVD|BDRip|MKV|XviD|WMV|d3g|BDREMUX|REMUX|^(?=.*1080p)(?=.*HEVC)|[xh][-_. ]?26[45]|German.*DL|((?<=\\d{4}).*German.*(DL)?)(?=.*\\b(AVC|HEVC|VC[-_. ]?1|MVC|MPEG[-_. ]?2)\\b))\\b)(((?=.*\\b(Blu[-_. ]?ray|BD|HD[-_. ]?DVD)\\b)(?=.*\\b(AVC|HEVC|VC[-_. ]?1|MVC|MPEG[-_. ]?2|BDMV|ISO)\\b))|^((?=.*\\b(^((?=.*\\b((.*_)?COMPLETE.*|Dis[ck])\\b)(?=.*(Blu[-_. ]?ray|HD[-_. ]?DVD)))|3D[-_. ]?BD|BR[-_. ]?DISK|Full[-_. ]?Blu[-_. ]?ray|^((?=.*((BD|UHD)[-_. ]?(25|50|66|100|ISO)))))))).*|(?i)(DVD9|DVD5|NTSC|PAL|VOB IFO|VC-1|AVC|MPEG-2|\\bCOMPLETE[-.\\s]?(?:UHD[-.\\s])?BLU[-.\\s]?RAY\\b|\\bCOMPLETE BLURAY\\b|\\bBR-Disk\\b)",
-            "type": "textbox",
-            "advanced": false,
-            "privacy": "normal",
-            "isFloat": false
-          }
-        ]
-      },
-      {
-        "name": "Remux",
-        "implementation": "ReleaseTitleSpecification",
-        "implementationName": "Release Title",
-        "infoLink": "https://wiki.servarr.com/radarr/settings#custom-formats-2",
-        "negate": true,
-        "required": true,
-        "fields": [
-          {
-            "order": 0,
-            "name": "value",
-            "label": "Regular Expression",
-            "helpText": "Custom Format RegEx is Case Insensitive",
-            "value": "Remux",
-            "type": "textbox",
-            "advanced": false,
-            "privacy": "normal",
-            "isFloat": false
-          }
-        ]
-      },
-      {
-        "name": "WEB",
-        "implementation": "SourceSpecification",
-        "implementationName": "Source",
-        "infoLink": "https://wiki.servarr.com/radarr/settings#custom-formats-2",
-        "negate": false,
-        "required": true,
-        "fields": [
-          {
-            "order": 0,
-            "name": "value",
-            "label": "Source",
-            "value": 7,
-            "type": "select",
-            "advanced": false,
-            "selectOptions": [
-              {
-                "value": 0,
-                "name": "UNKNOWN",
-                "order": 0,
-                "dividerAfter": false
-              },
-              {
-                "value": 1,
-                "name": "CAM",
-                "order": 1,
-                "dividerAfter": false
-              },
-              {
-                "value": 2,
-                "name": "TELESYNC",
-                "order": 2,
-                "dividerAfter": false
-              },
-              {
-                "value": 3,
-                "name": "TELECINE",
-                "order": 3,
-                "dividerAfter": false
-              },
-              {
-                "value": 4,
-                "name": "WORKPRINT",
-                "order": 4,
-                "dividerAfter": false
-              },
-              {
-                "value": 5,
-                "name": "DVD",
-                "order": 5,
-                "dividerAfter": false
-              },
-              {
-                "value": 6,
-                "name": "TV",
-                "order": 6,
-                "dividerAfter": false
-              },
-              {
-                "value": 7,
-                "name": "WEBDL",
-                "order": 7,
-                "dividerAfter": false
-              },
-              {
-                "value": 8,
-                "name": "WEBRIP",
-                "order": 8,
-                "dividerAfter": false
-              },
-              {
-                "value": 9,
-                "name": "BLURAY",
-                "order": 9,
-                "dividerAfter": false
-              }
-            ],
-            "privacy": "normal",
-            "isFloat": false
-          }
-        ]
-      },
-      {
-        "name": "4k",
-        "implementation": "ResolutionSpecification",
-        "implementationName": "Resolution",
-        "infoLink": "https://wiki.servarr.com/radarr/settings#custom-formats-2",
-        "negate": true,
-        "required": true,
-        "fields": [
-          {
-            "order": 0,
-            "name": "value",
-            "label": "Resolution",
-            "value": 2160,
-            "type": "select",
-            "advanced": false,
-            "selectOptions": [
-              {
-                "value": 0,
-                "name": "Unknown",
-                "order": 0,
-                "dividerAfter": false
-              },
-              {
-                "value": 360,
-                "name": "R360p",
-                "order": 360,
-                "dividerAfter": false
-              },
-              {
-                "value": 480,
-                "name": "R480p",
-                "order": 480,
-                "dividerAfter": false
-              },
-              {
-                "value": 540,
-                "name": "R540p",
-                "order": 540,
-                "dividerAfter": false
-              },
-              {
-                "value": 576,
-                "name": "R576p",
-                "order": 576,
-                "dividerAfter": false
-              },
-              {
-                "value": 720,
-                "name": "R720p",
-                "order": 720,
-                "dividerAfter": false
-              },
-              {
-                "value": 1080,
-                "name": "R1080p",
-                "order": 1080,
-                "dividerAfter": false
-              },
-              {
-                "value": 2160,
-                "name": "R2160p",
-                "order": 2160,
-                "dividerAfter": false
-              }
-            ],
-            "privacy": "normal",
-            "isFloat": false
-          }
-        ]
-      }
+        {
+            "name": "h265",
+            "implementation": "ReleaseTitleSpecification",
+            "implementationName": "Release Title",
+            "infoLink": "https://wiki.servarr.com/sonarr/settings#custom-formats-2",
+            "negate": false,
+            "required": true,
+            "fields": [
+                {
+                    "order": 0,
+                    "name": "value",
+                    "label": "Regular Expression",
+                    "helpText": "Custom Format RegEx is Case Insensitive",
+                    "value": "(?i)h\\s*\\.?\\s*265",
+                    "type": "textbox",
+                    "advanced": false,
+                    "privacy": "normal",
+                    "isFloat": false
+                }
+            ]
+        },
+        {
+            "name": "Disc",
+            "implementation": "ReleaseTitleSpecification",
+            "implementationName": "Release Title",
+            "infoLink": "https://wiki.servarr.com/sonarr/settings#custom-formats-2",
+            "negate": true,
+            "required": true,
+            "fields": [
+                {
+                    "order": 0,
+                    "name": "value",
+                    "label": "Regular Expression",
+                    "helpText": "Custom Format RegEx is Case Insensitive",
+                    "value": "^(?!.*\\b((?<!HD[._ -]|HD)DVD|BDRip|MKV|XviD|WMV|d3g|BDREMUX|REMUX|^(?=.*1080p)(?=.*HEVC)|[xh][-_. ]?26[45]|German.*DL|((?<=\\d{4}).*German.*(DL)?)(?=.*\\b(AVC|HEVC|VC[-_. ]?1|MVC|MPEG[-_. ]?2)\\b))\\b)(((?=.*\\b(Blu[-_. ]?ray|BD|HD[-_. ]?DVD)\\b)(?=.*\\b(AVC|HEVC|VC[-_. ]?1|MVC|MPEG[-_. ]?2|BDMV|ISO)\\b))|^((?=.*\\b(^((?=.*\\b((.*_)?COMPLETE.*|Dis[ck])\\b)(?=.*(Blu[-_. ]?ray|HD[-_. ]?DVD)))|3D[-_. ]?BD|BR[-_. ]?DISK|Full[-_. ]?Blu[-_. ]?ray|^((?=.*((BD|UHD)[-_. ]?(25|50|66|100|ISO)))))))).*|(?i)(DVD9|DVD5|NTSC|PAL|VOB IFO|VC-1|AVC|MPEG-2|\\bCOMPLETE[-.\\s]?(?:UHD[-.\\s])?BLU[-.\\s]?RAY\\b|\\bCOMPLETE BLURAY\\b|\\bBR-Disk\\b)",
+                    "type": "textbox",
+                    "advanced": false,
+                    "privacy": "normal",
+                    "isFloat": false
+                }
+            ]
+        },
+        {
+            "name": "Remux",
+            "implementation": "ReleaseTitleSpecification",
+            "implementationName": "Release Title",
+            "infoLink": "https://wiki.servarr.com/sonarr/settings#custom-formats-2",
+            "negate": true,
+            "required": true,
+            "fields": [
+                {
+                    "order": 0,
+                    "name": "value",
+                    "label": "Regular Expression",
+                    "helpText": "Custom Format RegEx is Case Insensitive",
+                    "value": "Remux",
+                    "type": "textbox",
+                    "advanced": false,
+                    "privacy": "normal",
+                    "isFloat": false
+                }
+            ]
+        },
+        {
+            "name": "WEB",
+            "implementation": "SourceSpecification",
+            "implementationName": "Source",
+            "infoLink": "https://wiki.servarr.com/sonarr/settings#custom-formats-2",
+            "negate": false,
+            "required": true,
+            "fields": [
+                {
+                    "order": 0,
+                    "name": "value",
+                    "label": "Source",
+                    "value": 3,
+                    "type": "select",
+                    "advanced": false,
+                    "selectOptions": [
+                        {
+                            "value": 0,
+                            "name": "Unknown",
+                            "order": 0
+                        },
+                        {
+                            "value": 1,
+                            "name": "Television",
+                            "order": 1
+                        },
+                        {
+                            "value": 2,
+                            "name": "TelevisionRaw",
+                            "order": 2
+                        },
+                        {
+                            "value": 3,
+                            "name": "Web",
+                            "order": 3
+                        },
+                        {
+                            "value": 4,
+                            "name": "WebRip",
+                            "order": 4
+                        },
+                        {
+                            "value": 5,
+                            "name": "DVD",
+                            "order": 5
+                        },
+                        {
+                            "value": 6,
+                            "name": "Bluray",
+                            "order": 6
+                        },
+                        {
+                            "value": 7,
+                            "name": "BlurayRaw",
+                            "order": 7
+                        }
+                    ],
+                    "privacy": "normal",
+                    "isFloat": false
+                }
+            ]
+        },
+        {
+            "name": "4k",
+            "implementation": "ResolutionSpecification",
+            "implementationName": "Resolution",
+            "infoLink": "https://wiki.servarr.com/sonarr/settings#custom-formats-2",
+            "negate": true,
+            "required": true,
+            "fields": [
+                {
+                    "order": 0,
+                    "name": "value",
+                    "label": "Resolution",
+                    "value": 2160,
+                    "type": "select",
+                    "advanced": false,
+                    "selectOptions": [
+                        {
+                            "value": 0,
+                            "name": "Unknown",
+                            "order": 0
+                        },
+                        {
+                            "value": 360,
+                            "name": "R360P",
+                            "order": 360
+                        },
+                        {
+                            "value": 480,
+                            "name": "R480P",
+                            "order": 480
+                        },
+                        {
+                            "value": 540,
+                            "name": "R540p",
+                            "order": 540
+                        },
+                        {
+                            "value": 576,
+                            "name": "R576p",
+                            "order": 576
+                        },
+                        {
+                            "value": 720,
+                            "name": "R720p",
+                            "order": 720
+                        },
+                        {
+                            "value": 1080,
+                            "name": "R1080p",
+                            "order": 1080
+                        },
+                        {
+                            "value": 2160,
+                            "name": "R2160p",
+                            "order": 2160
+                        }
+                    ],
+                    "privacy": "normal",
+                    "isFloat": false
+                }
+            ]
+        },
+        {
+            "name": "Verified groups",
+            "implementation": "ReleaseTitleSpecification",
+            "implementationName": "Release Title",
+            "infoLink": "https://wiki.servarr.com/sonarr/settings#custom-formats-2",
+            "negate": false,
+            "required": true,
+            "fields": [
+                {
+                    "order": 0,
+                    "name": "value",
+                    "label": "Regular Expression",
+                    "helpText": "Custom Format RegEx is Case Insensitive",
+                    "value": "(?<=^|[\\s.-])(HONE|SIGMA|SiGLA|DarQ|YELLO|Yoyo|GRiMM|HECATE|BLAZE|AnoZu)(?![.\\d])",
+                    "type": "textbox",
+                    "advanced": false,
+                    "privacy": "normal",
+                    "isFloat": false
+                }
+            ]
+        }
     ]
   },
   {

--- a/imports/custom_formats/sonarr/custom formats (sonarr - master).json
+++ b/imports/custom_formats/sonarr/custom formats (sonarr - master).json
@@ -10738,196 +10738,217 @@
     ]
   },
   {
-    "name": "h265",
+    "name": "h265-Dictionarry",
     "includeCustomFormatWhenRenaming": false,
     "specifications": [
-      {
-        "name": "h265",
-        "implementation": "ReleaseTitleSpecification",
-        "implementationName": "Release Title",
-        "infoLink": "https://wiki.servarr.com/sonarr/settings#custom-formats-2",
-        "negate": false,
-        "required": true,
-        "fields": [
-          {
-            "order": 0,
-            "name": "value",
-            "label": "Regular Expression",
-            "helpText": "Custom Format RegEx is Case Insensitive",
-            "value": "(?i)h\\s*\\.?\\s*265",
-            "type": "textbox",
-            "advanced": false,
-            "privacy": "normal",
-            "isFloat": false
-          }
-        ]
-      },
-      {
-        "name": "Disc",
-        "implementation": "ReleaseTitleSpecification",
-        "implementationName": "Release Title",
-        "infoLink": "https://wiki.servarr.com/sonarr/settings#custom-formats-2",
-        "negate": true,
-        "required": true,
-        "fields": [
-          {
-            "order": 0,
-            "name": "value",
-            "label": "Regular Expression",
-            "helpText": "Custom Format RegEx is Case Insensitive",
-            "value": "^(?!.*\\b((?<!HD[._ -]|HD)DVD|BDRip|MKV|XviD|WMV|d3g|BDREMUX|REMUX|^(?=.*1080p)(?=.*HEVC)|[xh][-_. ]?26[45]|German.*DL|((?<=\\d{4}).*German.*(DL)?)(?=.*\\b(AVC|HEVC|VC[-_. ]?1|MVC|MPEG[-_. ]?2)\\b))\\b)(((?=.*\\b(Blu[-_. ]?ray|BD|HD[-_. ]?DVD)\\b)(?=.*\\b(AVC|HEVC|VC[-_. ]?1|MVC|MPEG[-_. ]?2|BDMV|ISO)\\b))|^((?=.*\\b(^((?=.*\\b((.*_)?COMPLETE.*|Dis[ck])\\b)(?=.*(Blu[-_. ]?ray|HD[-_. ]?DVD)))|3D[-_. ]?BD|BR[-_. ]?DISK|Full[-_. ]?Blu[-_. ]?ray|^((?=.*((BD|UHD)[-_. ]?(25|50|66|100|ISO)))))))).*|(?i)(DVD9|DVD5|NTSC|PAL|VOB IFO|VC-1|AVC|MPEG-2|\\bCOMPLETE[-.\\s]?(?:UHD[-.\\s])?BLU[-.\\s]?RAY\\b|\\bCOMPLETE BLURAY\\b|\\bBR-Disk\\b)",
-            "type": "textbox",
-            "advanced": false,
-            "privacy": "normal",
-            "isFloat": false
-          }
-        ]
-      },
-      {
-        "name": "Remux",
-        "implementation": "ReleaseTitleSpecification",
-        "implementationName": "Release Title",
-        "infoLink": "https://wiki.servarr.com/sonarr/settings#custom-formats-2",
-        "negate": true,
-        "required": true,
-        "fields": [
-          {
-            "order": 0,
-            "name": "value",
-            "label": "Regular Expression",
-            "helpText": "Custom Format RegEx is Case Insensitive",
-            "value": "Remux",
-            "type": "textbox",
-            "advanced": false,
-            "privacy": "normal",
-            "isFloat": false
-          }
-        ]
-      },
-      {
-        "name": "WEB",
-        "implementation": "SourceSpecification",
-        "implementationName": "Source",
-        "infoLink": "https://wiki.servarr.com/sonarr/settings#custom-formats-2",
-        "negate": false,
-        "required": true,
-        "fields": [
-          {
-            "order": 0,
-            "name": "value",
-            "label": "Source",
-            "value": 3,
-            "type": "select",
-            "advanced": false,
-            "selectOptions": [
-              {
-                "value": 0,
-                "name": "Unknown",
-                "order": 0
-              },
-              {
-                "value": 1,
-                "name": "Television",
-                "order": 1
-              },
-              {
-                "value": 2,
-                "name": "TelevisionRaw",
-                "order": 2
-              },
-              {
-                "value": 3,
-                "name": "Web",
-                "order": 3
-              },
-              {
-                "value": 4,
-                "name": "WebRip",
-                "order": 4
-              },
-              {
-                "value": 5,
-                "name": "DVD",
-                "order": 5
-              },
-              {
-                "value": 6,
-                "name": "Bluray",
-                "order": 6
-              },
-              {
-                "value": 7,
-                "name": "BlurayRaw",
-                "order": 7
-              }
-            ],
-            "privacy": "normal",
-            "isFloat": false
-          }
-        ]
-      },
-      {
-        "name": "4k",
-        "implementation": "ResolutionSpecification",
-        "implementationName": "Resolution",
-        "infoLink": "https://wiki.servarr.com/sonarr/settings#custom-formats-2",
-        "negate": true,
-        "required": true,
-        "fields": [
-          {
-            "order": 0,
-            "name": "value",
-            "label": "Resolution",
-            "value": 2160,
-            "type": "select",
-            "advanced": false,
-            "selectOptions": [
-              {
-                "value": 0,
-                "name": "Unknown",
-                "order": 0
-              },
-              {
-                "value": 360,
-                "name": "R360P",
-                "order": 360
-              },
-              {
-                "value": 480,
-                "name": "R480P",
-                "order": 480
-              },
-              {
-                "value": 540,
-                "name": "R540p",
-                "order": 540
-              },
-              {
-                "value": 576,
-                "name": "R576p",
-                "order": 576
-              },
-              {
-                "value": 720,
-                "name": "R720p",
-                "order": 720
-              },
-              {
-                "value": 1080,
-                "name": "R1080p",
-                "order": 1080
-              },
-              {
-                "value": 2160,
-                "name": "R2160p",
-                "order": 2160
-              }
-            ],
-            "privacy": "normal",
-            "isFloat": false
-          }
-        ]
-      }
+        {
+            "name": "h265",
+            "implementation": "ReleaseTitleSpecification",
+            "implementationName": "Release Title",
+            "infoLink": "https://wiki.servarr.com/sonarr/settings#custom-formats-2",
+            "negate": false,
+            "required": true,
+            "fields": [
+                {
+                    "order": 0,
+                    "name": "value",
+                    "label": "Regular Expression",
+                    "helpText": "Custom Format RegEx is Case Insensitive",
+                    "value": "(?i)h\\s*\\.?\\s*265",
+                    "type": "textbox",
+                    "advanced": false,
+                    "privacy": "normal",
+                    "isFloat": false
+                }
+            ]
+        },
+        {
+            "name": "Disc",
+            "implementation": "ReleaseTitleSpecification",
+            "implementationName": "Release Title",
+            "infoLink": "https://wiki.servarr.com/sonarr/settings#custom-formats-2",
+            "negate": true,
+            "required": true,
+            "fields": [
+                {
+                    "order": 0,
+                    "name": "value",
+                    "label": "Regular Expression",
+                    "helpText": "Custom Format RegEx is Case Insensitive",
+                    "value": "^(?!.*\\b((?<!HD[._ -]|HD)DVD|BDRip|MKV|XviD|WMV|d3g|BDREMUX|REMUX|^(?=.*1080p)(?=.*HEVC)|[xh][-_. ]?26[45]|German.*DL|((?<=\\d{4}).*German.*(DL)?)(?=.*\\b(AVC|HEVC|VC[-_. ]?1|MVC|MPEG[-_. ]?2)\\b))\\b)(((?=.*\\b(Blu[-_. ]?ray|BD|HD[-_. ]?DVD)\\b)(?=.*\\b(AVC|HEVC|VC[-_. ]?1|MVC|MPEG[-_. ]?2|BDMV|ISO)\\b))|^((?=.*\\b(^((?=.*\\b((.*_)?COMPLETE.*|Dis[ck])\\b)(?=.*(Blu[-_. ]?ray|HD[-_. ]?DVD)))|3D[-_. ]?BD|BR[-_. ]?DISK|Full[-_. ]?Blu[-_. ]?ray|^((?=.*((BD|UHD)[-_. ]?(25|50|66|100|ISO)))))))).*|(?i)(DVD9|DVD5|NTSC|PAL|VOB IFO|VC-1|AVC|MPEG-2|\\bCOMPLETE[-.\\s]?(?:UHD[-.\\s])?BLU[-.\\s]?RAY\\b|\\bCOMPLETE BLURAY\\b|\\bBR-Disk\\b)",
+                    "type": "textbox",
+                    "advanced": false,
+                    "privacy": "normal",
+                    "isFloat": false
+                }
+            ]
+        },
+        {
+            "name": "Remux",
+            "implementation": "ReleaseTitleSpecification",
+            "implementationName": "Release Title",
+            "infoLink": "https://wiki.servarr.com/sonarr/settings#custom-formats-2",
+            "negate": true,
+            "required": true,
+            "fields": [
+                {
+                    "order": 0,
+                    "name": "value",
+                    "label": "Regular Expression",
+                    "helpText": "Custom Format RegEx is Case Insensitive",
+                    "value": "Remux",
+                    "type": "textbox",
+                    "advanced": false,
+                    "privacy": "normal",
+                    "isFloat": false
+                }
+            ]
+        },
+        {
+            "name": "WEB",
+            "implementation": "SourceSpecification",
+            "implementationName": "Source",
+            "infoLink": "https://wiki.servarr.com/sonarr/settings#custom-formats-2",
+            "negate": false,
+            "required": true,
+            "fields": [
+                {
+                    "order": 0,
+                    "name": "value",
+                    "label": "Source",
+                    "value": 3,
+                    "type": "select",
+                    "advanced": false,
+                    "selectOptions": [
+                        {
+                            "value": 0,
+                            "name": "Unknown",
+                            "order": 0
+                        },
+                        {
+                            "value": 1,
+                            "name": "Television",
+                            "order": 1
+                        },
+                        {
+                            "value": 2,
+                            "name": "TelevisionRaw",
+                            "order": 2
+                        },
+                        {
+                            "value": 3,
+                            "name": "Web",
+                            "order": 3
+                        },
+                        {
+                            "value": 4,
+                            "name": "WebRip",
+                            "order": 4
+                        },
+                        {
+                            "value": 5,
+                            "name": "DVD",
+                            "order": 5
+                        },
+                        {
+                            "value": 6,
+                            "name": "Bluray",
+                            "order": 6
+                        },
+                        {
+                            "value": 7,
+                            "name": "BlurayRaw",
+                            "order": 7
+                        }
+                    ],
+                    "privacy": "normal",
+                    "isFloat": false
+                }
+            ]
+        },
+        {
+            "name": "4k",
+            "implementation": "ResolutionSpecification",
+            "implementationName": "Resolution",
+            "infoLink": "https://wiki.servarr.com/sonarr/settings#custom-formats-2",
+            "negate": true,
+            "required": true,
+            "fields": [
+                {
+                    "order": 0,
+                    "name": "value",
+                    "label": "Resolution",
+                    "value": 2160,
+                    "type": "select",
+                    "advanced": false,
+                    "selectOptions": [
+                        {
+                            "value": 0,
+                            "name": "Unknown",
+                            "order": 0
+                        },
+                        {
+                            "value": 360,
+                            "name": "R360P",
+                            "order": 360
+                        },
+                        {
+                            "value": 480,
+                            "name": "R480P",
+                            "order": 480
+                        },
+                        {
+                            "value": 540,
+                            "name": "R540p",
+                            "order": 540
+                        },
+                        {
+                            "value": 576,
+                            "name": "R576p",
+                            "order": 576
+                        },
+                        {
+                            "value": 720,
+                            "name": "R720p",
+                            "order": 720
+                        },
+                        {
+                            "value": 1080,
+                            "name": "R1080p",
+                            "order": 1080
+                        },
+                        {
+                            "value": 2160,
+                            "name": "R2160p",
+                            "order": 2160
+                        }
+                    ],
+                    "privacy": "normal",
+                    "isFloat": false
+                }
+            ]
+        },
+        {
+            "name": "Verified groups",
+            "implementation": "ReleaseTitleSpecification",
+            "implementationName": "Release Title",
+            "infoLink": "https://wiki.servarr.com/sonarr/settings#custom-formats-2",
+            "negate": false,
+            "required": true,
+            "fields": [
+                {
+                    "order": 0,
+                    "name": "value",
+                    "label": "Regular Expression",
+                    "helpText": "Custom Format RegEx is Case Insensitive",
+                    "value": "(?<=^|[\\s.-])(HONE|SIGMA|SiGLA|DarQ|YELLO|Yoyo|GRiMM|HECATE|BLAZE|AnoZu)(?![.\\d])",
+                    "type": "textbox",
+                    "advanced": false,
+                    "privacy": "normal",
+                    "isFloat": false
+                }
+            ]
+        }
     ]
   },
   {

--- a/imports/custom_formats/sonarr/custom formats (sonarr - master).json
+++ b/imports/custom_formats/sonarr/custom formats (sonarr - master).json
@@ -10738,7 +10738,7 @@
     ]
   },
   {
-    "name": "h265-Dictionarry",
+    "name": "h265",
     "includeCustomFormatWhenRenaming": false,
     "specifications": [
         {


### PR DESCRIPTION
As discussed on Discord, an H265 1080p release group whitelist is necessary to filter out the absurd amount of mislabelled releases. As few groups are releasing proper untouched H265 WEB-DLs, this whitelist shouldn't be too difficult to maintain, and ensures a high quality standard for the HEVC profile.

The groups added have at least 25 releases on HUNO. Further release group inclusion guidelines to be agreed later.